### PR TITLE
Temporarily disable fsst and fast-pfor

### DIFF
--- a/converter/java/build.gradle
+++ b/converter/java/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation 'org.apache.orc:orc-core:1.8.1'
     implementation 'com.github.davidmoten:hilbert-curve:0.2.2'
     implementation 'org.roaringbitmap:RoaringBitmap:0.9.38'
-    implementation files('libs/fsst-1.0-SNAPSHOT.jar')
+    // implementation files('libs/fsst-1.0-SNAPSHOT.jar')
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'

--- a/converter/java/src/main/java/com/mlt/decoder/StringDecoder.java
+++ b/converter/java/src/main/java/com/mlt/decoder/StringDecoder.java
@@ -1,6 +1,6 @@
 package com.mlt.decoder;
 
-import com.fsst.FsstEncoder;
+// import com.fsst.FsstEncoder;
 import com.mlt.metadata.stream.DictionaryType;
 import com.mlt.metadata.stream.LengthType;
 import com.mlt.metadata.stream.StreamMetadataDecoder;
@@ -77,8 +77,9 @@ public class StringDecoder {
 
         List<String> dictionary = null;
         if(symbolTableStream != null){
-            var utf8Values = FsstEncoder.decode(symbolTableStream, symbolLengthStream.stream().mapToInt(i -> i).toArray(), dictionaryStream);
-            dictionary = decodeDictionary(dictionaryLengthStream, utf8Values);
+            System.out.println("symbolTableStream cannot be used as FSST is currently disabled");
+            // var utf8Values = FsstEncoder.decode(symbolTableStream, symbolLengthStream.stream().mapToInt(i -> i).toArray(), dictionaryStream);
+            // dictionary = decodeDictionary(dictionaryLengthStream, utf8Values);
         }
         else {
             dictionary = decodeDictionary(dictionaryLengthStream, dictionaryStream);
@@ -194,10 +195,12 @@ public class StringDecoder {
         }
 
         if(symbolTableStream != null){
-            var utf8Values = FsstEncoder.decode(symbolTableStream, symbolLengthStream.stream().mapToInt(i -> i).toArray(), dictionaryStream);
-            return Triple.of(numValues, presentStream, decodeDictionary(presentStream, dictionaryLengthStream, utf8Values, offsetStream, numValues));
+            System.out.println("symbolTableStream cannot be used as FSST is currently disabled");
+            // var utf8Values = FsstEncoder.decode(symbolTableStream, symbolLengthStream.stream().mapToInt(i -> i).toArray(), dictionaryStream);
+            // return Triple.of(numValues, presentStream, decodeDictionary(presentStream, dictionaryLengthStream, utf8Values, offsetStream, numValues));
         }
-        else if(dictionaryStream != null){
+        // else if(dictionaryStream != null){
+        if(dictionaryStream != null){
             return Triple.of(numValues, presentStream, decodeDictionary(presentStream, dictionaryLengthStream, dictionaryStream, offsetStream, numValues));
         }
         else{
@@ -252,49 +255,49 @@ public class StringDecoder {
         return values;
     }
 
-    public static List<String> decodeFsstDictionaryEncodedStringColumn(byte[] data, IntWrapper offset) throws IOException {
-        /* FsstDictionary -> SymbolTable, SymbolLength, CompressedCorups, Length, Data */
-        //TODO: get rid of that IntWrapper creation
-        var symbolTableOffset = new IntWrapper(offset.get());
-        var symbolTableMetadata = StreamMetadataDecoder.decode(data, symbolTableOffset);
-        var symbolLengthOffset = new IntWrapper(symbolTableOffset.get() + symbolTableMetadata.byteLength());
-        var symbolLengthMetadata = StreamMetadataDecoder.decode(data, symbolLengthOffset);
-        var compressedCorpusOffset = new IntWrapper(symbolLengthOffset.get() + symbolLengthMetadata.byteLength());
-        var compressedCorpusMetadata = StreamMetadataDecoder.decode(data, compressedCorpusOffset);
-        var lengthOffset = new IntWrapper(compressedCorpusOffset.get() + compressedCorpusMetadata.byteLength());
-        var lengthMetadata = StreamMetadataDecoder.decode(data, lengthOffset);
-        var dataOffset = new IntWrapper(lengthOffset.get() + lengthMetadata.byteLength());
-        var dataMetadata = StreamMetadataDecoder.decode(data, dataOffset);
+    // public static List<String> decodeFsstDictionaryEncodedStringColumn(byte[] data, IntWrapper offset) throws IOException {
+    //     /* FsstDictionary -> SymbolTable, SymbolLength, CompressedCorups, Length, Data */
+    //     //TODO: get rid of that IntWrapper creation
+    //     var symbolTableOffset = new IntWrapper(offset.get());
+    //     var symbolTableMetadata = StreamMetadataDecoder.decode(data, symbolTableOffset);
+    //     var symbolLengthOffset = new IntWrapper(symbolTableOffset.get() + symbolTableMetadata.byteLength());
+    //     var symbolLengthMetadata = StreamMetadataDecoder.decode(data, symbolLengthOffset);
+    //     var compressedCorpusOffset = new IntWrapper(symbolLengthOffset.get() + symbolLengthMetadata.byteLength());
+    //     var compressedCorpusMetadata = StreamMetadataDecoder.decode(data, compressedCorpusOffset);
+    //     var lengthOffset = new IntWrapper(compressedCorpusOffset.get() + compressedCorpusMetadata.byteLength());
+    //     var lengthMetadata = StreamMetadataDecoder.decode(data, lengthOffset);
+    //     var dataOffset = new IntWrapper(lengthOffset.get() + lengthMetadata.byteLength());
+    //     var dataMetadata = StreamMetadataDecoder.decode(data, dataOffset);
 
-        //TODO: get rid of that copy by refactoring the fsst decoding function
-        var symbols = Arrays.copyOfRange(data, symbolTableOffset.get(), symbolTableOffset.get()
-                + symbolTableMetadata.byteLength());
-        var symbolLength = IntegerDecoder.decodeIntStream(data, symbolLengthOffset, symbolLengthMetadata, false);
-        var compressedCorpus = Arrays.copyOfRange(data, compressedCorpusOffset.get(),
-                compressedCorpusOffset.get() + compressedCorpusMetadata.byteLength());
-        var values = FsstEncoder.decode(symbols, symbolLength.stream().mapToInt(i -> i).toArray(), compressedCorpus);
+    //     //TODO: get rid of that copy by refactoring the fsst decoding function
+    //     var symbols = Arrays.copyOfRange(data, symbolTableOffset.get(), symbolTableOffset.get()
+    //             + symbolTableMetadata.byteLength());
+    //     var symbolLength = IntegerDecoder.decodeIntStream(data, symbolLengthOffset, symbolLengthMetadata, false);
+    //     var compressedCorpus = Arrays.copyOfRange(data, compressedCorpusOffset.get(),
+    //             compressedCorpusOffset.get() + compressedCorpusMetadata.byteLength());
+    //     var values = FsstEncoder.decode(symbols, symbolLength.stream().mapToInt(i -> i).toArray(), compressedCorpus);
 
-        var length = IntegerDecoder.decodeIntStream(data, lengthOffset, lengthMetadata, false);
-        var decodedData = IntegerDecoder.decodeIntStream(data, dataOffset, dataMetadata, false);
+    //     var length = IntegerDecoder.decodeIntStream(data, lengthOffset, lengthMetadata, false);
+    //     var decodedData = IntegerDecoder.decodeIntStream(data, dataOffset, dataMetadata, false);
 
-        var decodedDictionary = new ArrayList<String>();
-        var strStart = 0;
-        for(var l : length){
-            var v = Arrays.copyOfRange(values, strStart, strStart + l);
-            decodedDictionary.add(new String(v, StandardCharsets.UTF_8));
-            strStart += l;
-        }
+    //     var decodedDictionary = new ArrayList<String>();
+    //     var strStart = 0;
+    //     for(var l : length){
+    //         var v = Arrays.copyOfRange(values, strStart, strStart + l);
+    //         decodedDictionary.add(new String(v, StandardCharsets.UTF_8));
+    //         strStart += l;
+    //     }
 
-        var decodedValues = new ArrayList<String>(decodedData.size());
-        for(var dictionaryOffset : decodedData){
-            var value = decodedDictionary.get(dictionaryOffset);
-            decodedValues.add(value);
-        }
+    //     var decodedValues = new ArrayList<String>(decodedData.size());
+    //     for(var dictionaryOffset : decodedData){
+    //         var value = decodedDictionary.get(dictionaryOffset);
+    //         decodedValues.add(value);
+    //     }
 
-        //TODO: check -> is this correct?
-        offset.set(dataOffset.get());
+    //     //TODO: check -> is this correct?
+    //     offset.set(dataOffset.get());
 
-        return decodedValues;
-    }
+    //     return decodedValues;
+    // }
 
 }

--- a/converter/java/src/main/java/com/mlt/decoder/vectorized/VectorizedStringDecoder.java
+++ b/converter/java/src/main/java/com/mlt/decoder/vectorized/VectorizedStringDecoder.java
@@ -10,8 +10,8 @@ import com.mlt.vector.dictionary.DictionaryDataVector;
 import com.mlt.vector.dictionary.StringDictionaryVector;
 import com.mlt.vector.dictionary.StringSharedDictionaryVector;
 import com.mlt.vector.flat.StringFlatVector;
-import com.mlt.vector.fsstdictionary.StringFsstDictionaryVector;
-import com.mlt.vector.fsstdictionary.StringSharedFsstDictionaryVector;
+// import com.mlt.vector.fsstdictionary.StringFsstDictionaryVector;
+// import com.mlt.vector.fsstdictionary.StringSharedFsstDictionaryVector;
 import me.lemire.integercompression.IntWrapper;
 
 import java.io.IOException;
@@ -71,10 +71,12 @@ public class VectorizedStringDecoder {
         }
 
         if(symbolTableStream != null){
-            return decodeFsstDictionary(name, bitVector, offsetStream, dictionaryLengthStream, dictionaryStream,
-                    symbolLengthStream, symbolTableStream);
+            System.out.println("symbolTableStream cannot be used as FSST is currently disabled");
+            // return decodeFsstDictionary(name, bitVector, offsetStream, dictionaryLengthStream, dictionaryStream,
+            //         symbolLengthStream, symbolTableStream);
         }
-        else if(dictionaryStream != null){
+        // else if(dictionaryStream != null){
+        if(dictionaryStream != null){
             return decodeDictionary(name, bitVector, offsetStream, dictionaryLengthStream, dictionaryStream);
         }
 
@@ -125,10 +127,12 @@ public class VectorizedStringDecoder {
         }
 
         if(symbolTableStream != null){
-            return decodeFsstDictionary(name, bitVector, offsetStream, dictionaryLengthStream, dictionaryStream,
-                    symbolLengthStream, symbolTableStream);
+            System.out.println("symbolTableStream cannot be used as FSST is currently disabled");
+            // return decodeFsstDictionary(name, bitVector, offsetStream, dictionaryLengthStream, dictionaryStream,
+            //         symbolLengthStream, symbolTableStream);
         }
-        else if(dictionaryStream != null){
+        // else if(dictionaryStream != null){
+        if(dictionaryStream != null){
             return decodeDictionary(name, bitVector, offsetStream, dictionaryLengthStream, dictionaryStream);
         }
 
@@ -198,9 +202,14 @@ public class VectorizedStringDecoder {
             fieldVectors[i++] = dataVector;
         }
 
-        return symbolTableBuffer != null? new StringSharedFsstDictionaryVector(column.getName(), dictionaryLengthBuffer,
-                dictionaryBuffer, symbolLengthBuffer, symbolTableBuffer, fieldVectors) :
-                new StringSharedDictionaryVector(column.getName(), dictionaryLengthBuffer, dictionaryBuffer, fieldVectors);
+        if (symbolTableBuffer != null) {
+            System.out.println("symbolTableBuffer cannot be used as FSST is currently disabled");
+            // return new StringSharedFsstDictionaryVector(column.getName(), dictionaryLengthBuffer,
+            // dictionaryBuffer, symbolLengthBuffer, symbolTableBuffer, fieldVectors);
+        }
+        // } else {
+        return new StringSharedDictionaryVector(column.getName(), dictionaryLengthBuffer, dictionaryBuffer, fieldVectors);
+        // }
     }
 
     public static Vector decodeSharedDictionaryToRandomAccessFormat(
@@ -270,9 +279,14 @@ public class VectorizedStringDecoder {
             fieldVectors[i++] = dataVector;
         }
 
-        return symbolTableBuffer != null? new StringSharedFsstDictionaryVector(column.getName(), dictionaryLengthBuffer,
-                dictionaryBuffer, symbolLengthBuffer, symbolTableBuffer, fieldVectors) :
-                new StringSharedDictionaryVector(column.getName(), dictionaryLengthBuffer, dictionaryBuffer, fieldVectors);
+        if (symbolTableBuffer != null) {
+            System.out.println("symbolTableBuffer cannot be used as FSST is currently disabled");
+            // return new StringSharedFsstDictionaryVector(column.getName(), dictionaryLengthBuffer,
+            // dictionaryBuffer, symbolLengthBuffer, symbolTableBuffer, fieldVectors);
+        }
+        // } else {
+        return new StringSharedDictionaryVector(column.getName(), dictionaryLengthBuffer, dictionaryBuffer, fieldVectors);
+        // }
     }
 
     private static StringFlatVector decodePlain(String name, BitVector nullabilityVector, IntBuffer lengthStream,
@@ -285,12 +299,12 @@ public class VectorizedStringDecoder {
         return new StringDictionaryVector(name, nullabilityVector, dictionaryOffsets, lengthStream, utf8Values);
     }
 
-    private static StringFsstDictionaryVector decodeFsstDictionary(String name, BitVector nullabilityVector,
-                                                               IntBuffer dictionaryOffsets, IntBuffer lengthStream,
-                                                               ByteBuffer utf8Values, IntBuffer symbolLengthStream,
-                                                               ByteBuffer symbolTable){
-        return new StringFsstDictionaryVector(name, nullabilityVector, dictionaryOffsets, lengthStream,
-                utf8Values, symbolLengthStream, symbolTable);
-    }
+    // private static StringFsstDictionaryVector decodeFsstDictionary(String name, BitVector nullabilityVector,
+    //                                                            IntBuffer dictionaryOffsets, IntBuffer lengthStream,
+    //                                                            ByteBuffer utf8Values, IntBuffer symbolLengthStream,
+    //                                                            ByteBuffer symbolTable){
+    //     return new StringFsstDictionaryVector(name, nullabilityVector, dictionaryOffsets, lengthStream,
+    //             utf8Values, symbolLengthStream, symbolTable);
+    // }
 
 }

--- a/converter/java/src/test/java/com/mlt/converter/MltConverterTest.java
+++ b/converter/java/src/test/java/com/mlt/converter/MltConverterTest.java
@@ -138,7 +138,7 @@ public class MltConverterTest { ;
         var optimization = new FeatureTableOptimizations(allowSorting, allowIdRegeneration, columnMappings);
         //TODO: fix -> either add columMappings per layer or global like when creating the scheme
         var optimizations = Map.of("place", optimization, "water_name", optimization);
-        var conversionConfig = new ConversionConfig(true, true, optimizations);
+        var conversionConfig = new ConversionConfig(true, false, optimizations);
         var mlTile = MltConverter.convertMvt(mvTile, conversionConfig, tileMetadata);
 
         var decodedMlTile = MltDecoder.decodeMlTile(mlTile, tileMetadata);
@@ -252,7 +252,7 @@ public class MltConverterTest { ;
         var optimization = new FeatureTableOptimizations(allowSorting, allowIdRegeneration, columnMappings);
         //TODO: fix -> either add columMappings per layer or global like when creating the scheme
         var optimizations = Map.of("place", optimization, "water_name", optimization);
-        var conversionConfig = new ConversionConfig(true, true, optimizations);
+        var conversionConfig = new ConversionConfig(true, false, optimizations);
         var mlTile = MltConverter.convertMvt(mvTile, conversionConfig, tileMetadata);
 
         //var decodedMlTile = MltDecoder.decodeMlTile(mlTile, tileMetadata);
@@ -286,7 +286,7 @@ public class MltConverterTest { ;
                     var optimization = new FeatureTableOptimizations(allowSorting, allowIdRegeneration, columnMappings);
                     //TODO: fix -> either add columMappings per layer or global like when creating the scheme
                     var optimizations = Map.of("place", optimization, "water_name", optimization);
-                    var conversionConfig = new ConversionConfig(true, true, optimizations);
+                    var conversionConfig = new ConversionConfig(true, false, optimizations);
                     var mlTile = MltConverter.convertMvt(decodedMvTile, conversionConfig, tileMetadata);
 
                     //var decodedMlTile = MltDecoder.decodeMlTile(mlTile, tileMetadata);
@@ -408,7 +408,7 @@ public class MltConverterTest { ;
         var optimization = new FeatureTableOptimizations(allowSorting, allowIdRegeneration, columnMappings);
         //TODO: fix -> either add columMappings per layer or global like when creating the scheme
         var optimizations = Map.of("place", optimization, "water_name", optimization);
-        var conversionConfig = new ConversionConfig(true, true, optimizations);
+        var conversionConfig = new ConversionConfig(true, false, optimizations);
         var mlTile = MltConverter.convertMvt(decodedMvTile, conversionConfig, tileMetadata);
 
         var decodedMlTile = MltDecoder.decodeMlTile(mlTile, tileMetadata);

--- a/converter/java/src/test/java/com/mlt/decoder/MltDecoderBenchmark.java
+++ b/converter/java/src/test/java/com/mlt/decoder/MltDecoderBenchmark.java
@@ -70,7 +70,7 @@ public class MltDecoderBenchmark {
         var optimization = new FeatureTableOptimizations(allowSorting, allowIdRegeneration, columnMappings);
         //TODO: fix -> either add columMappings per layer or global like when creating the scheme
         var optimizations = Map.of("place", optimization, "water_name", optimization, "transportation", optimization);
-        var mlTile = MltConverter.convertMvt(mvTile, new ConversionConfig(true, true, optimizations),
+        var mlTile = MltConverter.convertMvt(mvTile, new ConversionConfig(true, false, optimizations),
                 tileMetadata);
 
         var mltTimeElapsed = 0l;

--- a/converter/java/src/test/java/com/mlt/decoder/MltDecoderTest.java
+++ b/converter/java/src/test/java/com/mlt/decoder/MltDecoderTest.java
@@ -76,7 +76,7 @@ public class MltDecoderTest {
         var optimization = new FeatureTableOptimizations(allowSorting, allowIdRegeneration, columnMappings);
         //TODO: fix -> either add columMappings per layer or global like when creating the scheme
         var optimizations = Map.of("place", optimization, "water_name", optimization, "transportation", optimization);
-        var mlTile = MltConverter.convertMvt(mvTile, new ConversionConfig(true, true, optimizations),
+        var mlTile = MltConverter.convertMvt(mvTile, new ConversionConfig(true, false, optimizations),
                 tileMetadata);
 
         var decodedTile = MltDecoder.decodeMlTile(mlTile, tileMetadata);
@@ -161,7 +161,7 @@ public class MltDecoderTest {
         var optimization = new FeatureTableOptimizations(allowSorting, allowIdRegeneration, columnMappings);
         //TODO: fix -> either add columMappings per layer or global like when creating the scheme
         var optimizations = Map.of("place", optimization, "water_name", optimization, "transportation", optimization);
-        var mlTile = MltConverter.convertMvt(mvTile, new ConversionConfig(true, true, optimizations),
+        var mlTile = MltConverter.convertMvt(mvTile, new ConversionConfig(true, false, optimizations),
                 tileMetadata);
 
         var decodedTile = MltDecoder.decodeMlTileVectorized(mlTile, tileMetadata);

--- a/converter/java/src/test/java/com/mlt/decoder/StringDecoderTest.java
+++ b/converter/java/src/test/java/com/mlt/decoder/StringDecoderTest.java
@@ -20,25 +20,25 @@ import java.util.Optional;
 public class StringDecoderTest {
     private static final String OMT_MVT_PATH = Paths.get("..","..","test","fixtures","omt","mvt").toString();
 
-    @Test
-    public void decodeSharedDictionary_FsstDictionaryEncoded() throws IOException {
-        var values1 = List.of("TestTestTestTestTestTest", "TestTestTestTestTestTest1", "TestTestTestTestTestTest2",
-                "TestTestTestTestTestTest2", "TestTestTestTestTestTest4");
-        var values2 = List.of("TestTestTestTestTestTest6", "TestTestTestTestTestTest5", "TestTestTestTestTestTest8",
-                "TestTestTestTestTestTes9", "TestTestTestTestTestTest10");
-        var values = List.of(values1, values2);
-        var encodedValues = StringEncoder.encodeSharedDictionary(values, PhysicalLevelTechnique.FAST_PFOR);
+    // @Test
+    // public void decodeSharedDictionary_FsstDictionaryEncoded() throws IOException {
+    //     var values1 = List.of("TestTestTestTestTestTest", "TestTestTestTestTestTest1", "TestTestTestTestTestTest2",
+    //             "TestTestTestTestTestTest2", "TestTestTestTestTestTest4");
+    //     var values2 = List.of("TestTestTestTestTestTest6", "TestTestTestTestTestTest5", "TestTestTestTestTestTest8",
+    //             "TestTestTestTestTestTes9", "TestTestTestTestTestTest10");
+    //     var values = List.of(values1, values2);
+    //     var encodedValues = StringEncoder.encodeSharedDictionary(values, PhysicalLevelTechnique.FAST_PFOR);
 
-        var tileMetadata = MltTilesetMetadata.Column.newBuilder().setName("Test").setNullable(true).
-                setScalarType(MltTilesetMetadata.ScalarColumn.newBuilder().setPhysicalType(MltTilesetMetadata.ScalarType.STRING)).build();
+    //     var tileMetadata = MltTilesetMetadata.Column.newBuilder().setName("Test").setNullable(true).
+    //             setScalarType(MltTilesetMetadata.ScalarColumn.newBuilder().setPhysicalType(MltTilesetMetadata.ScalarType.STRING)).build();
 
-        var decodedValues = StringDecoder.
-                decodeSharedDictionary(encodedValues.getRight(), new IntWrapper(0), tileMetadata);
+    //     var decodedValues = StringDecoder.
+    //             decodeSharedDictionary(encodedValues.getRight(), new IntWrapper(0), tileMetadata);
 
-        var v = decodedValues.getRight();
-        Assert.equals(values1, v.get(":Test"));
-        Assert.equals(values2, v.get(":Test2"));
-    }
+    //     var v = decodedValues.getRight();
+    //     Assert.equals(values1, v.get(":Test"));
+    //     Assert.equals(values2, v.get(":Test2"));
+    // }
 
     @Test
     public void decodeSharedDictionary_DictonaryEncoded() throws IOException {
@@ -102,47 +102,47 @@ public class StringDecoderTest {
         Assert.equals(values2, v.get(":Test2"));
     }
 
-    @Test
-    public void decodeSharedDictionary_NullValues_FsstDictonaryEncoded() throws IOException {
-        var values1 = Arrays.asList(null, null, null, null, "TestTestTestTestTestTest", "TestTestTestTestTestTest1",
-                null, "TestTestTestTestTestTest2", "TestTestTestTestTestTest2", "TestTestTestTestTestTest4");
-        var values2 = Arrays.asList("TestTestTestTestTestTest6", null, "TestTestTestTestTestTest5", "TestTestTestTestTestTest8",
-                "TestTestTestTestTestTes9", null, "TestTestTestTestTestTest10");
-        var values = List.of(values1, values2);
-        var encodedValues = StringEncoder.encodeSharedDictionary(values, PhysicalLevelTechnique.FAST_PFOR);
+    // @Test
+    // public void decodeSharedDictionary_NullValues_FsstDictonaryEncoded() throws IOException {
+    //     var values1 = Arrays.asList(null, null, null, null, "TestTestTestTestTestTest", "TestTestTestTestTestTest1",
+    //             null, "TestTestTestTestTestTest2", "TestTestTestTestTestTest2", "TestTestTestTestTestTest4");
+    //     var values2 = Arrays.asList("TestTestTestTestTestTest6", null, "TestTestTestTestTestTest5", "TestTestTestTestTestTest8",
+    //             "TestTestTestTestTestTes9", null, "TestTestTestTestTestTest10");
+    //     var values = List.of(values1, values2);
+    //     var encodedValues = StringEncoder.encodeSharedDictionary(values, PhysicalLevelTechnique.FAST_PFOR);
 
-        var test = MltTilesetMetadata.Field.newBuilder().setName("Test").setScalarField(
-                MltTilesetMetadata.ScalarField.newBuilder().setPhysicalType(MltTilesetMetadata.ScalarType.STRING).build());
-        var test2 = MltTilesetMetadata.Field.newBuilder().setName("Test2").setScalarField(
-                MltTilesetMetadata.ScalarField.newBuilder().setPhysicalType(MltTilesetMetadata.ScalarType.STRING).build());
-        var tileMetadata = MltTilesetMetadata.Column.newBuilder().setName("Parent").setNullable(true).setComplexType(
-                MltTilesetMetadata.ComplexColumn.newBuilder().addChildren(test).addChildren(test2).build()).build();
+    //     var test = MltTilesetMetadata.Field.newBuilder().setName("Test").setScalarField(
+    //             MltTilesetMetadata.ScalarField.newBuilder().setPhysicalType(MltTilesetMetadata.ScalarType.STRING).build());
+    //     var test2 = MltTilesetMetadata.Field.newBuilder().setName("Test2").setScalarField(
+    //             MltTilesetMetadata.ScalarField.newBuilder().setPhysicalType(MltTilesetMetadata.ScalarType.STRING).build());
+    //     var tileMetadata = MltTilesetMetadata.Column.newBuilder().setName("Parent").setNullable(true).setComplexType(
+    //             MltTilesetMetadata.ComplexColumn.newBuilder().addChildren(test).addChildren(test2).build()).build();
 
-        var decodedValues = StringDecoder.
-                decodeSharedDictionary(encodedValues.getRight(), new IntWrapper(0), tileMetadata);
+    //     var decodedValues = StringDecoder.
+    //             decodeSharedDictionary(encodedValues.getRight(), new IntWrapper(0), tileMetadata);
 
-        var v = decodedValues.getRight();
+    //     var v = decodedValues.getRight();
 
-        var actualValues1 = v.get(":Test");
-        var p1 = decodedValues.getMiddle().get(":Test");
-        var decodedV1 = new ArrayList<String>();
-        var counter = 0;
-        for(var i = 0; i < decodedValues.getMiddle().size(); i++){
-            var a = p1.get(i)? actualValues1.get(counter++) : null;
-            decodedV1.add(a);
-        }
-        var actualValues2 = v.get(":Test2");
-        var p2 = decodedValues.getMiddle().get(":Test2");
-        var decodedV2 = new ArrayList<String>();
-        var counter2 = 0;
-        for(var i = 0; i < decodedValues.getMiddle().size(); i++){
-            var a = p2.get(i)? actualValues2.get(counter2++) : null;
-            decodedV2.add(a);
-        }
+    //     var actualValues1 = v.get(":Test");
+    //     var p1 = decodedValues.getMiddle().get(":Test");
+    //     var decodedV1 = new ArrayList<String>();
+    //     var counter = 0;
+    //     for(var i = 0; i < decodedValues.getMiddle().size(); i++){
+    //         var a = p1.get(i)? actualValues1.get(counter++) : null;
+    //         decodedV1.add(a);
+    //     }
+    //     var actualValues2 = v.get(":Test2");
+    //     var p2 = decodedValues.getMiddle().get(":Test2");
+    //     var decodedV2 = new ArrayList<String>();
+    //     var counter2 = 0;
+    //     for(var i = 0; i < decodedValues.getMiddle().size(); i++){
+    //         var a = p2.get(i)? actualValues2.get(counter2++) : null;
+    //         decodedV2.add(a);
+    //     }
 
-        Assert.equals(values1, v.get(":Test"));
-        Assert.equals(values2, v.get(":Test2"));
-    }
+    //     Assert.equals(values1, v.get(":Test"));
+    //     Assert.equals(values2, v.get(":Test2"));
+    // }
 
     @Test
     public void decodeSharedDictionary_Mvt() throws IOException {


### PR DESCRIPTION
Two reasons for this:

 - To be able to get the java converter running on non-windows platforms
 - To lower the barrier to writing encoders that will not easily have access to these encodings in their first versions

Note: commenting code I think is the right approach right now because it's fast and will allow for things to be brought back quickly (when the time is right). But of course it be ideal to refactor the code to make the fast.dll only load if needed, but that is beyond my java expertise.